### PR TITLE
Avoid using XOR as power-of

### DIFF
--- a/src/ccluster/ccluster.c
+++ b/src/ccluster/ccluster.c
@@ -1085,10 +1085,7 @@ void connCmp_print_for_results_withOutput(FILE * f, const connCmp_t c, int outpu
 //     sprintf(temp, "%d", connCmp_nSols(c));
 //     for (int i = lens; i<=lensols; i++) sprintf(temp2, " ");
 //     fprintf(f, "--cluster with %s sols: ", temp);
-    if (connCmp_nSols(c) <= (10^6)-1)
-        fprintf(f, "#--cluster with %5d sols: ", connCmp_nSols(c));
-    else
-        fprintf(f, "#--cluster with %d sols: ", connCmp_nSols(c));
+    fprintf(f, "#--cluster with %5d sols: ", connCmp_nSols(c));
     
     connCmp_componentBox( containingBox, c, metadatas_initBref(meta));
     compBox_get_containing_dsk( containingDisk, containingBox);

--- a/src/risolate/risolate.c
+++ b/src/risolate/risolate.c
@@ -670,10 +670,7 @@ void connCmp_risolate_print_for_results_withOutput(FILE * f, const connCmp_t c, 
     compDsk_t containingDisk;
     compDsk_init(containingDisk);
     
-    if (connCmp_nSols(c) <= (10^6)-1)
-        fprintf(f, "#--solution with mult. %5d: ", connCmp_nSols(c));
-    else
-        fprintf(f, "#--solution with mult. %5d: ", connCmp_nSols(c));
+    fprintf(f, "#--solution with mult. %5d: ", connCmp_nSols(c));
     
     connCmp_componentBox( containingBox, c, metadatas_initBref(meta));
     risolate_compBox_get_containing_dsk( containingDisk, containingBox);


### PR DESCRIPTION
In C, the `^` operator is not exponentiation; it is XOR.  The value of `(10^6)` is 12, not 1000000.  In any case, the comparison is useless.  The printf field width value, 5 in this case, is a _minimum_ width.  Just pass that in all cases.  If the value to be printed fits into fewer than 5 characters, it will be padded with spaces on the left.  If it requires 5 or more characters to print, that many characters will be used to print.