### PR TITLE
Prevent multiple definition errors when linking

### DIFF
--- a/src/ccluster/parallel_discard.c
+++ b/src/ccluster/parallel_discard.c
@@ -15,6 +15,10 @@
 
 #ifdef CCLUSTER_HAVE_PTHREAD
 
+int parallel_discard_done;
+pthread_mutex_t parallel_discard_mdone;
+pthread_cond_t  parallel_discard_cdone;
+
 void * _parallel_discard_list_worker( void * arg_ptr ){
     
     parallel_discard_list_arg_t * arg = (parallel_discard_list_arg_t *) arg_ptr;

--- a/src/ccluster/parallel_discard.h
+++ b/src/ccluster/parallel_discard.h
@@ -33,9 +33,9 @@
 extern "C" {
 #endif
     
-int parallel_discard_done;
-pthread_mutex_t parallel_discard_mdone;
-pthread_cond_t  parallel_discard_cdone;
+extern int parallel_discard_done;
+extern pthread_mutex_t parallel_discard_mdone;
+extern pthread_cond_t  parallel_discard_cdone;
 
     
 typedef struct {


### PR DESCRIPTION
Modern versions of ld no longer make `-fcommon` the default.  Building without adding `-fcommon` to the build flags leads to errors like this:
```
/usr/bin/ld: ./src/ISSAC20/ccluster_issac20_interface.lo (symbol from plugin): in function `ccluster_issac20_global_interface_func':
(.text+0x0): multiple definition of `parallel_discard_cdone'; ./src/ISSAC20/ccluster_issac20.lo (symbol from plugin):(.text+0x0): first defined here
/usr/bin/ld: ./src/ISSAC20/ccluster_issac20_interface.lo (symbol from plugin): in function `ccluster_issac20_global_interface_func':
(.text+0x0): multiple definition of `parallel_discard_mdone'; ./src/ISSAC20/ccluster_issac20.lo (symbol from plugin):(.text+0x0): first defined here
```

Fix the issue by ensuring there is at most one definition of each of the affected symbols.