### PR TITLE
Hide number typedef

### DIFF
--- a/src/fpri/fpri.c
+++ b/src/fpri/fpri.c
@@ -11,6 +11,8 @@
 
 #include "fpri.h"
 
+typedef double number;
+
 void fpri_swap (fpri_t x, fpri_t y) {
     number t1 = x->low, t2 = x->upp;
     x->low = y->low;

--- a/src/fpri/fpri.h
+++ b/src/fpri/fpri.h
@@ -59,13 +59,12 @@ FPRI_INLINE void   _fpri_free(void * ptr)                 {        FPRI_DEFAULT_
                                               void *(*realloc_func) (void *, size_t),
                                               void  (*free_func)    (void *) );
 
-typedef double number;
 typedef struct {
     /* Assuming rounding upward; 
      *low stores MINUS the lower 
      * bound of the interval;*/
-    number low;
-    number upp;
+    double low;
+    double upp;
 } fpri_struct;
 
 typedef fpri_struct fpri_t[1];


### PR DESCRIPTION
Ccluster version 1.1.8 breaks the Singular build (when built with ccluster support), because of clashing typedefs named `number`.  The ccluster typedef doesn't need to be public, so hide it inside `fpri.c`.  Alternatively, you could change the name to something less generic.